### PR TITLE
Fix alpha format parsing

### DIFF
--- a/spire.h
+++ b/spire.h
@@ -12,6 +12,16 @@
 #include "spirepool.h"
 #include "types.h"
 
+struct ParsedLayoutValues
+{
+	unsigned floors;
+	std::string upgrades;
+	std::string core;
+	std::string traps;
+};
+
+std::ostream& operator<<(std::ostream& os, const ParsedLayoutValues& p);
+
 class Spire
 {
 private:
@@ -87,7 +97,8 @@ private:
 public:
 	Spire(int, char **);
 private:
-	void init_start_layout(const std::string &, const std::string &, unsigned, const std::string &);
+	ParsedLayoutValues parse_layout(const std::string &, const std::string &, const std::string &, unsigned);
+	void init_start_layout(const ParsedLayoutValues &);
 	void init_pools(unsigned);
 	void init_network(bool);
 public:


### PR DESCRIPTION
The alphanumeric format (i.e. the one output if --numeric wasn't specified) was not parseable as a format string.

This refactors the parsing code from init_layout, and explicitly checks the format (alpha/numeric) and parses them correctly.