### PR TITLE
Manually construct maximum 128-bit unsigned value

### DIFF
--- a/spiredb.cpp
+++ b/spiredb.cpp
@@ -242,7 +242,7 @@ void SpireDB::update_data()
 			core.set_mod(mod[0].as<unsigned>(), mod[1].as<uint16_t>());
 
 		core.update();
-		Number cost = min<Number>(core.cost, numeric_limits<int64_t>::max());
+		Number cost = min<Number>(core.cost, number_max);
 		xact.exec_prepared("update_core", id, cost, current_version);
 	}
 

--- a/spirelayout.cpp
+++ b/spirelayout.cpp
@@ -445,7 +445,7 @@ Layout::SimResult Layout::simulate(const vector<Step> &steps, Number hp, bool st
 {
 	SimResult result;
 	result.sim_hp = hp;
-	result.max_hp = numeric_limits<Number>::max();
+	result.max_hp = number_max;
 
 	if(detail)
 	{
@@ -621,7 +621,7 @@ void Layout::update_cost()
 	Number strength_cost = 3000;
 	Number condenser_cost = 6000;
 	Number knowledge_cost = 9000;
-	Number max_cost = numeric_limits<Number>::max();
+	Number max_cost = number_max;
 	cost = 0;
 	for(char t: data)
 	{
@@ -689,7 +689,7 @@ void Layout::update_threat(const vector<SimResult> &results)
 	{
 		threat = (low+high+1)/2;
 
-		static Number bias = numeric_limits<Number>::max()/2;
+		static Number bias = number_max/2;
 		Number change = bias;
 		integrate_results(results, threat, [&change, cells, floors](const SimResult &r, Number low_hp, Number high_hp)
 		{

--- a/types.h
+++ b/types.h
@@ -11,12 +11,16 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 typedef unsigned __int128 Number;
+// std::numeric_limits<unsigned __int128>::max() returns zero in some environments, so use
+// -1 cast to Number instead for the maximum representable unsigned 128-bit number.
+constexpr Number number_max = Number(-1);
 #pragma GCC diagnostic pop
 #else
 #error "128-bit integers are not available with this compiler"
 #endif
 #else
 typedef std::uint64_t Number;
+constexpr Number number_max = std::numeric_limits<Number>::max();
 #endif
 
 template<typename T>


### PR DESCRIPTION
`numeric_limits<Number>::max()` doesn't appear to work with `WITH_128BIT`, at least using `g++ v9.3.0` — it silently returns 0, which ruins a lot of the logic.